### PR TITLE
Add support for setting cookies

### DIFF
--- a/bin/wbench
+++ b/bin/wbench
@@ -25,6 +25,10 @@ options = {}.tap do |options|
       options[:user_agent] = user_agent
     end
 
+    opts.on("-c", "--cookie [COOKIE]", "Set the cookie (default: browsers' default cookie value)") do |cookie|
+      options[:cookie] = cookie
+    end
+
   end.parse!
 end
 

--- a/lib/wbench/browser.rb
+++ b/lib/wbench/browser.rb
@@ -16,10 +16,21 @@ module WBench
         SeleniumDriver.new(app, selenium_options)
       end
 
-      @url = Addressable::URI.parse(url).normalize.to_s
+      parsed_url = Addressable::URI.parse(url)
+      @url = parsed_url.normalize.to_s
+      if options[:cookie]
+        parsed_url.path = ''
+        @root_url = parsed_url.normalize.to_s
+        @cookie = options[:cookie]
+      end
     end
 
     def visit
+      if @cookie
+        session.visit(@root_url)
+        session.execute_script("document.cookie = '#{@cookie}'")
+      end
+
       session.visit(@url)
       wait_for_page
       session.execute_script(wbench_javascript)


### PR DESCRIPTION
We set feature flips in the rails session so it's useful to be able to craft an appropriate cookie before performing tests.

Currently this needs an extra visit to set the domains cookies. There may be a better way to do this...
