### PR TITLE
[Bugfix] timing_hash.rb:8:in `each': comparison of Hash with 1438133594940 failed (ArgumentError)

### DIFF
--- a/lib/javascripts/wbench.js
+++ b/lib/javascripts/wbench.js
@@ -95,15 +95,15 @@ window.WBench = {
   },
 
   performanceTimings: function() {
-    resultTimings = window.performance.timing;
+    resultTimings = window.performance.timing.toJSON();
 
     // Use user defined timings that are added via window.performance.mark('event name')
     if(typeof(window.performance.getEntriesByType) === 'function') {
       window.performance.getEntriesByType('mark').forEach(function(item) {
         resultTimings[item.name] = Math.ceil(window.performance.timing.navigationStart + item.startTime);
       });
-    };
+    }
 
     return resultTimings;
   }
-}
+};

--- a/spec/wbench/stats_spec.rb
+++ b/spec/wbench/stats_spec.rb
@@ -4,7 +4,7 @@ describe WBench::Stats do
       subject(:stats) { described_class.new([1,6,2,8,3]) }
 
       it 'returns the middle result' do
-        stats.median.should == 3
+        expect(stats.median).to eq(3)
       end
     end
 
@@ -12,7 +12,7 @@ describe WBench::Stats do
       subject(:stats) { described_class.new([1,6,2,8,3,9]) }
 
       it 'returns the higher of the two middle values' do
-        stats.median.should == 6
+        expect(stats.median).to eq(6)
       end
     end
   end
@@ -20,24 +20,36 @@ describe WBench::Stats do
   describe '#sum' do
     subject(:stats) { described_class.new([2,4,4,4,5,5,7,9]) }
 
-    its(:sum) { should == 40 } # see: http://en.wikipedia.org/wiki/Standard_deviation
+    describe '#sum' do
+      subject { super().sum }
+      it { is_expected.to eq(40) }
+    end # see: http://en.wikipedia.org/wiki/Standard_deviation
   end
 
   describe '#mean' do
     subject(:stats) { described_class.new([2,4,4,4,5,5,7,9]) }
 
-    its(:mean) { should == 5 } # see: http://en.wikipedia.org/wiki/Standard_deviation
+    describe '#mean' do
+      subject { super().mean }
+      it { is_expected.to eq(5) }
+    end # see: http://en.wikipedia.org/wiki/Standard_deviation
   end
 
   describe '#sample_variance' do
     subject(:stats) { described_class.new([2,4,4,4,5,5,7,9]) }
 
-    its(:sample_variance) { should == 4 } # see: http://en.wikipedia.org/wiki/Standard_deviation
+    describe '#sample_variance' do
+      subject { super().sample_variance }
+      it { is_expected.to eq(4) }
+    end # see: http://en.wikipedia.org/wiki/Standard_deviation
   end
 
   describe '#std_dev' do
     subject(:stats) { described_class.new([2,4,4,4,5,5,7,9]) }
 
-    its(:std_dev) { should == 2 } # see: http://en.wikipedia.org/wiki/Standard_deviation
+    describe '#std_dev' do
+      subject { super().std_dev }
+      it { is_expected.to eq(2) }
+    end # see: http://en.wikipedia.org/wiki/Standard_deviation
   end
 end

--- a/spec/wbench/timing_hash_spec.rb
+++ b/spec/wbench/timing_hash_spec.rb
@@ -4,17 +4,17 @@ describe WBench::TimingHash do
     subject { described_class.new(timings) }
 
     it 'removes keys with a value of 0' do
-      subject.should_not have_key :nope
+      expect(subject).not_to have_key :nope
     end
 
     it 'offsets each value by the starting(lowest) value' do
-      subject[:start].should == 0
-      subject[:middle].should == 5
-      subject[:end].should == 10
+      expect(subject[:start]).to eq(0)
+      expect(subject[:middle]).to eq(5)
+      expect(subject[:end]).to eq(10)
     end
 
     it 'orders the hash by value, lowest first' do
-      subject.first.should == [:start, 0]
+      expect(subject.first).to eq([:start, 0])
     end
   end
 end

--- a/spec/wbench/titleizer_spec.rb
+++ b/spec/wbench/titleizer_spec.rb
@@ -3,7 +3,7 @@ describe WBench::Titleizer do
     subject { described_class.new('dom loading time') }
 
     it 'outputs a title' do
-      subject.to_s.should == 'DOM Loading Time:'
+      expect(subject.to_s).to eq('DOM Loading Time:')
     end
   end
 end


### PR DESCRIPTION
Could you please check the implementation and working?
# Summary
- This PR fixed the this error
  -  `timing_hash.rb:8:in each: comparison of Hash with 1438133594940 failed (ArgumentError)`.
- This is a fix for this problem. 
  - https://github.com/desktoppr/wbench/issues/31#issuecomment-125814114 
# Fixes
- Maybe, I think window.performance.timing response was modified.
  So fixed to calculate the correct result from the modified response.
- Rspec is not working, so change RSpec 3 syntax in Transpec.
  - Transpec : https://github.com/yujinakayama/transpec
# error

I receive this error since July 23nd, 2015 (JP time).
It always error occurs.
It did not receive an error until July 22, 2015 (JP time).

Mac : OS X Yosemite 10.10.4
Ruby : ruby 2.1.3p242 (2014-09-19 revision 47630) [x86_64-darwin14.0]
Chrome : 44.0.2403.107 (64-bit)

``` bash
$ ./bin/wbench -l 1 http://www.google.com
/Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/timing_hash.rb:8:in `each': comparison of Hash with 1438133594940 failed (ArgumentError)
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/timing_hash.rb:8:in `min_by'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/timing_hash.rb:8:in `initialize'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/timings/browser.rb:9:in `new'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/timings/browser.rb:9:in `result'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/benchmark.rb:32:in `browser_results'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/benchmark.rb:20:in `block (3 levels) in run'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/browser.rb:34:in `visit'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/benchmark.rb:20:in `block (2 levels) in run'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/benchmark.rb:18:in `times'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/benchmark.rb:18:in `block in run'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/benchmark.rb:17:in `tap'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/benchmark.rb:17:in `run'
        from /Users/toshiyuki_hasegawa/workspace/wbench/lib/wbench/benchmark.rb:4:in `run'
        from ./bin/wbench:43:in `<main>'
```
