### PR TITLE
timing_hashash to exclude non-integer values

### DIFF
--- a/lib/wbench/timing_hash.rb
+++ b/lib/wbench/timing_hash.rb
@@ -2,7 +2,7 @@ module WBench
   class TimingHash < Hash
     def initialize(hash)
       # Remove 0 values as they indicate events that didn't occur
-      hash = hash.delete_if { |key, value| value == 0 }
+      hash = hash.delete_if { |key, value| value == 0 || value.is_a? Integer }
 
       # Grab the start time and offset the values against it.
       start_time = hash.min_by(&:last).last


### PR DESCRIPTION
#### Summary

Recent change in Chrome starts to include `toJson()` function into the result of `window.performance.timing` that causes Wbench from failing to compare result hash in `Wbench::TimingHash`.

I notice that some other environment such that Ubuntu + Firefox has similar but different issue by this `Wbench::TimingHash`.

Fix is to check hash value is Integer and exclude them if otherwise.  
#### Errors

```
/Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/timing_hash.rb:9:in `each': comparison of Hash with 1438435854271 failed (ArgumentError)
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/timing_hash.rb:9:in `min_by'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/timing_hash.rb:9:in `initialize'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/timings/browser.rb:9:in `new'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/timings/browser.rb:9:in `result'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/benchmark.rb:32:in `browser_results'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/benchmark.rb:20:in `block (3 levels) in run'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/browser.rb:34:in `visit'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/benchmark.rb:20:in `block (2 levels) in run'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/benchmark.rb:18:in `times'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/benchmark.rb:18:in `block in run'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/benchmark.rb:17:in `tap'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/benchmark.rb:17:in `run'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/lib/wbench/benchmark.rb:4:in `run'
  from /Users/shun/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/wbench-1.1.0/bin/wbench:43:in `<top (required)>'
  from /Users/shun/.rbenv/versions/2.2.1/bin/wbench:23:in `load'
  from /Users/shun/.rbenv/versions/2.2.1/bin/wbench:23:in `<main>'
```

```
[shun@mbp15] $ wbench -l 1 https://www.google.com                                                                                                                                                 [shun](2.2.1)
{"connectEnd"=>1438435854593, "connectStart"=>1438435854547, "domComplete"=>1438435854922, "domContentLoadedEventEnd"=>1438435854770, "domContentLoadedEventStart"=>1438435854732, "domInteractive"=>1438435854732, "domLoading"=>1438435854659, "domainLookupEnd"=>1438435854547, "domainLookupStart"=>1438435854542, "fetchStart"=>1438435854539, "loadEventEnd"=>1438435854925, "loadEventStart"=>1438435854922, "navigationStart"=>1438435854271, "redirectEnd"=>0, "redirectStart"=>0, "requestStart"=>1438435854594, "responseEnd"=>1438435854665, "responseStart"=>1438435854657, "secureConnectionStart"=>1438435854553, "toJSON"=>{}, "unloadEventEnd"=>0, "unloadEventStart"=>0}
```
