### PR TITLE
Fix Travis mime-types dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+before_install:
+  - gem install bundler

--- a/wbench.gemspec
+++ b/wbench.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'colorize'
   gem.add_dependency 'addressable'
 
+  # Required to fix builds in Travis, otherwise a version that requies Ruby 2.0 is used.
+  gem.add_development_dependency 'mime-types', '2.6.2'
+
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Travis throws a gem install error about mime-types requiring Ruby
2.0, unless we pre install a version that still supports Ruby 1.9.

---

Hullo

By chance I was fixing this on another project and noticed you guys had pretty much the same issue. I attempted doing a pre-install using a .travis.yml, as other have suggested. However that didn't work. I tested running `bundle install` against Ruby 1.9.3p551 on my machine and did not encounter this error, so this work around is only in place for Travis.

Report by another user that the issue is still around despite being closed:
https://github.com/travis-ci/travis-ci/issues/5145#issuecomment-213595831

As a test I rebased https://github.com/desktoppr/wbench/pull/39 (which is waiting on this CI fix) and all came up green: https://travis-ci.org/gerrywastaken/wbench/builds/128276308
